### PR TITLE
Added import feature to the bitmap editor for BMP (24-bit depth) and PNG files

### DIFF
--- a/JackBitmapEditor.html
+++ b/JackBitmapEditor.html
@@ -767,7 +767,7 @@
     </script>
 </head>
 <body onload="Init();">
-    <h1>Jack Bitmap Editor v2.6</h1>
+    <h1>Jack Bitmap Editor v2.7</h1>
     <p>
       See <a href="https://github.com/ErikUmble/JackBitmapEditor">here</a> for updates, feature documentation, and contributers.
     </p>
@@ -783,6 +783,12 @@
         <tr>
             <td><div id="grid"/></td>
             <td><textarea id="generatedCode" cols="50" rows="48" readonly="read-only"></textarea></td>                                
+        </tr>
+        <tr>
+            <td>
+              <label class="fileButton" for="inputImage">Import BMP (24-bit) or PNG file (use only black and white as colors to prevent unexpected results)</label>
+              <input type="file" id="inputImage" accept=".bmp, .png, image/bmp, image/png">
+            </td>
         </tr>
         <tr>
             <table>
@@ -914,5 +920,138 @@
             margin: .4rem 0;
         }
     </style>
+    <script>
+        // Add a listener to the file import button that triggers the parsing
+        document.getElementById("inputImage").addEventListener("change", function(event) {
+            const file = event.target.files[0];
+            if (!file) return;
+
+            const extension = file.name.toLowerCase().split('.').pop();
+
+            if (extension === "bmp") {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    const buffer = new Uint8Array(e.target.result);
+                    parseBMP(buffer);
+                    inputImage.value = "";
+                };
+                reader.readAsArrayBuffer(file);
+            } else if (extension === "png") {
+                parsePNG(file);
+                inputImage.value = "";
+            } else {
+                alert("This file type is not supported. Please upload a .bmp (24-bit) or .png image.");
+            }
+        });
+
+        // Parse a BMP file
+        function parseBMP(bytes) {
+            // Values in a BMP file are stored in little-endian format
+            const width = bytes[18] + (bytes[19] << 8);
+            const height = bytes[22] + (bytes[23] << 8);
+            const offset = bytes[10] + (bytes[11] << 8);
+            const depth = bytes[28];
+
+            if (depth !== 24) {
+                alert("Only 24-bit BMP files are supported. Please convert your BMP file to a 24-bit depth bitmap using Paint or an online converter tool.");
+                return;
+            }
+
+            // "The size of each row is rounded up to a multiple of 4 bytes (a 32-bit DWORD) by padding" (Wikipedia: BMP file format)
+            const rowSize = Math.floor((24 * width + 31) / 32) * 4;
+
+            // Each word in memory translates to 16 pixels on the Hack screen
+            const paddedWidth = Math.ceil(width / 16) * 16;
+            const paddedHeight = Math.ceil(height / 16) * 16;
+
+            WIDTH = paddedWidth;
+            HEIGHT = paddedHeight;
+
+            localStorage.setItem("width", WIDTH);
+            localStorage.setItem("height", HEIGHT);
+
+            grid = new Array(HEIGHT);
+            for (let i = 0; i < HEIGHT; i++) {
+                grid[i] = new Array(WIDTH).fill(false);
+            }
+
+            // Copy the BMP contents into the top-left corner of the canvas
+            for (let y = 0; y < height; y++) {
+                // "Bits fill from left-to-right, then bottom-to-top" (Wikipedia: BMP file format)
+                const row = height - 1 - y;
+                for (let x = 0; x < width; x++) {
+                    const index = offset + row * rowSize + x * 3;
+                    const blue = bytes[index];
+                    const green = bytes[index + 1];
+                    const red = bytes[index + 2];
+                    const luminance = (red + green + blue) / 3;
+                    grid[y][x] = luminance < 128;
+                }
+            }
+            // Update canvas size in the input fields
+            document.getElementById("inputWidth").value = WIDTH.toString();
+            document.getElementById("inputHeight").value = HEIGHT.toString();
+            DisplayGrid();
+        }
+
+        function parsePNG(file) {
+            const img = new Image();
+            const reader = new FileReader();
+
+            reader.onload = function(e) {
+                img.src = e.target.result;
+            };
+            reader.readAsDataURL(file);
+
+            img.onload = function() {
+                const width = img.width;
+                const height = img.height;
+                
+                // Each word in memory translates to 16 pixels on the Hack screen
+                const paddedWidth = Math.ceil(width / 16) * 16;
+                const paddedHeight = Math.ceil(height / 16) * 16;
+
+                WIDTH = paddedWidth;
+                HEIGHT = paddedHeight;
+
+                localStorage.setItem("width", WIDTH);
+                localStorage.setItem("height", HEIGHT);
+
+                // Create a temporary canvas to draw the PNG contents to
+                const canvas = document.createElement("canvas");
+                canvas.width = WIDTH;
+                canvas.height = HEIGHT;
+                const ctx = canvas.getContext("2d");
+
+                // Initialize the temporary canvas
+                ctx.fillStyle = "#ffffff";
+                ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+                // Start copying the PNG contents at the top-left corner
+                ctx.drawImage(img, 0, 0);
+
+                const imageData = ctx.getImageData(0, 0, WIDTH, HEIGHT).data;
+
+                grid = new Array(HEIGHT);
+                for (let y = 0; y < HEIGHT; y++) {
+                    grid[y] = new Array(WIDTH).fill(false);
+                    for (let x = 0; x < WIDTH; x++) {
+                        const index = (y * WIDTH + x) * 4;
+                        const r = imageData[index];
+                        const g = imageData[index + 1];
+                        const b = imageData[index + 2];
+                        const a = imageData[index + 3];
+
+                        const luminance = (r + g + b) / 3;
+
+                        grid[y][x] = (a > 0 && luminance < 250) ? true : false;
+                    }
+                }
+                document.getElementById("inputWidth").value = WIDTH.toString();
+                document.getElementById("inputHeight").value = HEIGHT.toString();
+                DisplayGrid();
+            };
+        }
+    </script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A convenient program for making it easier to create sprites and animations for the Jack (Hack) platform. 
 
 ## Version
-2.6 (added localStorage to save drawing even if tab is closed)
+2.7 (added an import feature for 24-bit .bmp files and .png files)
 
 ## Background
 Made for use in the course nand2tetris <https://nand2tetris.org>
@@ -46,8 +46,11 @@ The Hack screen is made up of 256 rows of 32 words, each of wich is a 16-bit num
 ##### Hack Assembly
 By generating code directly in assembly, the result can be significantly more efficient than the Jack code that gets compiled into assembly (can be roughly 50-70% less machine instructions for certain drawings, but is always at least as efficient as the Jack code). This feature is useful for those who are programming in assembly, or wanting extreamly time-critical graphics (in which case, the programmer may need to compile their source code, add the graphics functions, and adapt the program to call the graphics functions according to the specification).
 
+##### Import
+You can import a BMP file (24-bit depth) or a PNG file to the canvas. It will act like you drew it on the canvas. Only use colors black (#000000) and white (#ffffff) to prevent unexpected results.
+
 ## Contributers
-Golan Parashi, Ignacio del Valle Alles, Erik Umble, and Dino Krivić (Shimon Schocken and Noam Nisan developed the Jack programming language).
+Golan Parashi, Ignacio del Valle Alles, Erik Umble, Dino Krivić and Noa Vermeersch (Shimon Schocken and Noam Nisan developed the Jack programming language).
 If you think of any improvements, feel free to submit an issue or a pull request.
 
 ## License


### PR DESCRIPTION
There is now a button to import BMP (24-bit depth) files and PNG files to the canvas. Everything works like the user would have drawn the pixels on the canvas themselves.